### PR TITLE
Changed the puppet module for my needs to setup a clean TYPO3 6.2.0beta1 without any errors in InstallTool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Just clone the repo in your modules folder.
         version => '6.1.3',
         site_path => '/var/www/my-project',
         site_user => 'vagrant',
-        site_group => 'www-data'
+        site_group => 'www-data',
     }
 
-### With a prepared database-connection:
+### Example with a prepared database-connection:
 
     typo3::project { 'my-project':
         version => '6.1.3',
@@ -32,8 +32,36 @@ Just clone the repo in your modules folder.
         db_name => 'typo3_db',
         db_host => 'localhost',
         db_pass => 'secret',
-        db_user => 'typo3'
+        db_user => 'typo3',
     }
+
+### Example with a different directory for typo3 sources:
+
+    typo3::project { 'my-project':
+        version => '6.1.3',
+        typo3_src_path => '/var/www',
+        site_path => '/var/www/my-project',
+        site_user => 'vagrant',
+        site_group => 'www-data',
+    }
+
+### Example with own encryption key and installToolPassword in TYPO3 configuration file:
+
+    typo3::project { 'my-project':
+        version => '6.1.3',
+        site_path => '/var/www/my-project',
+        site_user => 'vagrant',
+        site_group => 'www-data',
+        local_conf => {
+            'sys' => {
+               'encryptionKey' => '47ac9add3f53f8464d33ee5785a2f25dc35e8da9fcea8bbc41eb9ced5f58574f326abcecf1924b5ab0d3229c038d7c37',
+            },
+            'be' => {
+               'installToolPassword' => 'bacb98acf97e0b6112b1d1b650b84971',
+            },
+        },
+    }
+
 
 ### With pre-installed extensions: **(only from their git repository at the time)**  
 You can install extensions from their git-repository. Many extensions can you find [here](http://git.typo3.org).
@@ -115,6 +143,30 @@ For a TYPO3 6.1.3 (v6) project:
     typo3_src -> typo3_src-6.1.3
     index.php -> typo3_src/index.php
     t3lib -> typo3_src/t3lib
+    typo3 -> typo3_src/typo3
+
+For a TYPO3 6.2.0beta1 (v6) project:
+
+    fileadmin/
+    fileadmin/.htaccess
+    fileadmin/_processed_/
+    fileadmin/_temp_/
+    fileadmin/user_upload/
+    typo3conf/.htaccess
+    typo3conf/LocalConfiguration.php
+    typo3conf/AdditionalConfiguration.php
+    typo3conf/extTables.php
+    typo3conf/ext/
+    typo3conf/ext/.htaccess
+    typo3conf/l10n/
+    uploads/
+    uploads/.htaccess
+    uploads/pics/
+    uploads/media/
+    uploads/tf/
+    typo3_src-6.1.3/
+    typo3_src -> typo3_src-6.1.3
+    index.php -> typo3_src/index.php
     typo3 -> typo3_src/typo3
 
 ## ToDo's

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -27,22 +27,22 @@ define typo3::install::source (
   $source_file = "${version}.tar.gz"
 
   exec { "Get ${name}":
-    command 	=> "wget ${typo3::params::download_url}/${version} -O ${source_file}",
-    cwd 		=> $path,
-    onlyif	    => "test ! -d typo3_src-${version}"
+    command => "wget ${typo3::params::download_url}/${version} -O ${source_file}",
+    cwd     => $path,
+    onlyif  => "test ! -d typo3_src-${version}"
   }
 
   exec { "Untar ${name}":
-    command 	=> "tar -xzf ${source_file}",
-    cwd 		=> $path,
-    require 	=> Exec["Get ${name}"],
-    creates 	=> "${path}/typo3_src-${version}"
+    command => "tar -xzf ${source_file}",
+    cwd     => $path,
+    require => Exec["Get ${name}"],
+    creates => "${path}/typo3_src-${version}"
   }
 
   exec { "Remove ${path}/${source_file}":
-    command 	=> "rm -f ${path}/${source_file}",
-    cwd 		=> $path,
-    require 	=> Exec["Untar ${name}"]
+    command => "rm -f ${path}/${source_file}",
+    cwd     => $path,
+    require => Exec["Untar ${name}"]
   }
 
 }

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -8,6 +8,10 @@
 #   TYPO3 version for project.
 #   Example: '6.1.3'
 #
+# [*typo3_src_path*]
+#   Path to TYPO3 sources.
+#   Example:  '/var/www/'
+#
 # [*site_path*]
 #   Path to project root.
 #   Example:  '/var/www/my-project'
@@ -42,6 +46,7 @@
 define typo3::project (
 
   $version,
+  $typo3_src_path = "",
   $site_path,
   $site_user,
   $site_group,
@@ -51,51 +56,70 @@ define typo3::project (
   $db_host = "",
   $db_name = "",
 
-  $extensions = []
+  $local_conf = [],
+  $extensions = [],
 
 ) {
 
   include typo3
 
+  if ( $site_user != $site_group ) {
+    $dir_permission     = 2770
+    $file_permission    = 660
+  } else {
+    $dir_permission     = 2755
+    $file_permission    = 644
+  }
+
+  unless ( $typo3_src_path ) {
+    $typo3_src_path     = $site_path
+  }
+
   typo3::install::source { "${name}-${version}":
     version => $version,
-    path	=> $site_path
+    path    => $typo3_src_path,
   }
 
   typo3::install::extension { $extensions:
     path    => "${site_path}/typo3conf/ext",
-    owner  	=> $site_user,
-    group  	=> $site_group
+    owner   => $site_user,
+    group   => $site_group,
   }
 
   File {
-    owner  	=> $site_user,
-    group  	=> $site_group
+    owner   => $site_user,
+    group   => $site_group
   }
 
   file { "${site_path}/typo3_src":
-    ensure  => "${site_path}/typo3_src-${version}",
+    ensure  => 'link',
+    target  => "${typo3_src_path}/typo3_src-${version}",
     force   => true,
     replace => true,
     require => Typo3::Install::Source["${name}-${version}"]
   }
 
-  file { "${site_path}/index.php":
-    ensure  => "${site_path}/typo3_src/index.php",
-    replace => true,
-    require => File["${site_path}/typo3_src"]
+  exec { "ln -s typo3_src/index.php index.php":
+    command => 'ln -s typo3_src/index.php index.php',
+    cwd     => $site_path,
+    require => File["${site_path}/typo3_src"],
+    unless  => 'test -L index.php',
   }
 
-  file { "${site_path}/t3lib":
-    ensure  => "${site_path}/typo3_src/t3lib",
-    replace => true,
-    require => File["${site_path}/typo3_src"]
+  unless $version =~ /^6\.2/ {
+    exec { "ln -s typo3_src/t3lib t3lib":
+      command   => 'ln -s typo3_src/t3lib t3lib',
+      cwd       => $site_path,
+      require   => File["${site_path}/typo3_src"],
+      unless    => 'test -L t3lib',
+    }
   }
 
-  file { "${site_path}/typo3":
-    ensure	=> "${site_path}/typo3_src/typo3",
-    replace	=> true,
-    require => File["${site_path}/typo3_src"]
+  exec { "ln -s typo3_src/typo3 typo3":
+    command => 'ln -s typo3_src/typo3 typo3',
+    cwd     => $site_path,
+    require => File["${site_path}/typo3_src"],
+    unless  => 'test -L typo3',
   }
 
   file {[
@@ -112,7 +136,7 @@ define typo3::project (
     "${site_path}/typo3conf/ext"
   ]:
     ensure  => "directory",
-    mode	=> 755
+    mode    => $dir_permission
   }
 
   file { "${site_path}/typo3conf/extTables.php":
@@ -130,7 +154,7 @@ define typo3::project (
   ]:
     replace => "no",
     ensure  => "present",
-    mode	=> 644,
+    mode    => $file_permission,
     content => template('typo3/.htaccess.erb'),
     require => [
       File["${site_path}/fileadmin"],
@@ -143,35 +167,35 @@ define typo3::project (
   if $version =~ /^4\./ {
 
     file { "${site_path}/typo3conf/localconf.php":
-      replace => "no",
-      ensure  => "present",
-      content => template('typo3/localconf.php.erb'),
-      mode    => 644,
-      require => File["${site_path}/typo3conf"],
+      replace   => "no",
+      ensure    => "present",
+      content   => template('typo3/localconf.php.erb'),
+      mode      => $file_permission,
+      require   => File["${site_path}/typo3conf"],
     }
 
   } elsif $version =~ /^6\./ {
 
     File {
-      replace => "no",
-      ensure  => "present",
-      mode    => 644
+      replace   => "no",
+      ensure    => "present",
+      mode      => $file_permission
     }
 
     file { "${site_path}/typo3conf/LocalConfiguration.php":
-      content => template('typo3/LocalConfiguration.php.erb'),
+      content   => template('typo3/LocalConfiguration.php.erb'),
     }
 
     file { "${site_path}/typo3conf/AdditionalConfiguration.php":
-      content => template('typo3/AdditionalConfiguration.php.erb'),
+      content   => template('typo3/AdditionalConfiguration.php.erb'),
     }
 
     file {[
       "${site_path}/fileadmin/_processed_"
     ]:
-      ensure  => "directory",
-      mode	=> 755,
-      require => File["${site_path}/fileadmin"]
+      ensure    => "directory",
+      mode      => $dir_permission,
+      require   => File["${site_path}/fileadmin"]
     }
 
   }

--- a/templates/LocalConfiguration.php.erb
+++ b/templates/LocalConfiguration.php.erb
@@ -4,6 +4,11 @@ return array(
     'BE' => array(
         'disable_exec_function' => 0,
         'installToolPassword' => 'bacb98acf97e0b6112b1d1b650b84971',
+<% if @local_conf and @local_conf['be'] and @local_conf['be'].kind_of?(Hash) -%>
+<% @local_conf['be'].each do |key, conf| -%>
+        '<%= key -%>' => '<%= conf -%>',
+<% end -%>
+<% end -%>
     ),
     'DB' => array(
         'database' => '<%= @db_name %>',
@@ -54,8 +59,8 @@ return array(
             'indexed_search',
             'recycler',
             'version',
-            <% if extensions.is_a? Array -%>
-            <% extensions.each do |ext| %>'<%= ext['key'] %>',<% end %>
+            <% if @extensions.is_a? Array -%>
+            <% @extensions.each do |ext| %>'<%= ext['key'] %>',<% end %>
             <% end -%>
         ),
     ),
@@ -69,13 +74,28 @@ return array(
     'FE' => array(
         'lifetime' => '3600',
         'sessionDataLifetime' => '3600',
+<% if @local_conf and @local_conf['fe'] and @local_conf['fe'].kind_of?(Hash) -%>
+<% @local_conf['fe'].each do |key, conf| -%>
+        '<%= key -%>' => '<%= conf -%>',
+<% end -%>
+<% end -%>
     ),
     'GFX' => array(
         'jpg_quality' => '100',
+<% if @local_conf and @local_conf['gfx'] and @local_conf['gfx'].kind_of?(Hash) -%>
+<% @local_conf['gfx'].each do |key, conf| -%>
+        '<%= key -%>' => '<%= conf -%>',
+<% end -%>
+<% end -%>
     ),
     'SYS' => array(
         'compat_version' => '<%= @version %>',
         'sitename' => '<%= @name %>',
+<% if @local_conf and @local_conf['sys'] and @local_conf['sys'].kind_of?(Hash) -%>
+<% @local_conf['sys'].each do |key, conf| -%>
+        '<%= key -%>' => '<%= conf -%>',
+<% end -%>
+<% end -%>
     ),
 );
 

--- a/templates/localconf.php.erb
+++ b/templates/localconf.php.erb
@@ -18,4 +18,27 @@ $typo_db_extTableDef_script = 'extTables.php';
 ## INSTALL SCRIPT EDIT POINT TOKEN - all lines after this points may be changed by the install script!
 $TYPO3_CONF_VARS['SYS']['sitename'] = '<%= @name %>';
 
+<% if @local_conf and @local_conf['be'] and @local_conf['be'].kind_of?(Hash) -%>
+<% @local_conf['be'].each do |key, conf| -%>
+$TYPO3_CONF_VARS['BE']['<%= key -%>'] = '<%= conf -%>';
+<% end -%>
+<% end -%>
+
+<% if @local_conf and @local_conf['fe'] and @local_conf['fe'].kind_of?(Hash) -%>
+<% @local_conf['fe'].each do |key, conf| -%>
+$TYPO3_CONF_VARS['FE']['<%= key -%>'] = '<%= conf -%>';
+<% end -%>
+<% end -%>
+
+<% if @local_conf and @local_conf['gfx'] and @local_conf['gfx'].kind_of?(Hash) -%>
+<% @local_conf['gfx'].each do |key, conf| -%>
+$TYPO3_CONF_VARS['GFX']['<%= key -%>'] = '<%= conf -%>';
+<% end -%>
+<% end -%>
+
+<% if @local_conf and @local_conf['sys'] and @local_conf['sys'].kind_of?(Hash) -%>
+<% @local_conf['sys'].each do |key, conf| -%>
+$TYPO3_CONF_VARS['SYS']['<%= key -%>'] = '<%= conf -%>';
+<% end -%>
+<% end -%>
 ?>


### PR DESCRIPTION
add some configuration options like typo3_src_path and local_conf
change directory permissions for typo3 6.2
change install directory for typo3 sources to typo3_src_path if given
change symbolic links to typo3, t3lib and index.php

update readme
use space not tab
