### PR TITLE
Add an Exec Path + use function versioncmp for version Checks

### DIFF
--- a/manifests/install/extension.pp
+++ b/manifests/install/extension.pp
@@ -52,20 +52,23 @@ define typo3::install::extension (
     cwd         => $path,
     onlyif      => "test ! -d ${path}/${key}",
     require     => Package[$typo3::packages],
+    path        => ['/bin/'],
   }
 
   exec {"git-checkout ${key} ${version}":
     command     => "git checkout ${tag_name}",
     cwd         => "${path}/${key}",
     notify      => Exec["chown ${key}"],
-    require     => Exec["git-clone ${key}"]
+    require     => Exec["git-clone ${key}"],
+    path        => ['/bin/'],
   }
 
   exec {"chown ${key}":
     command     => "chown -R ${owner}:${group} ${path}/${key}",
     refreshonly => true,
     cwd         => $path,
-    require     => Exec["git-clone ${key}"]
+    require     => Exec["git-clone ${key}"],
+    path        => ['/bin/'],
   }
 
 }

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -45,7 +45,7 @@ define typo3::install::source (
     command => "rm -f ${src_path}/${source_file}",
     cwd     => $src_path,
     require => Exec["Untar ${name}"],
-    onlyif  => "test ! -f ${src_path}/${source_file}",
+    onlyif  => "test -f ${src_path}/${source_file}",
     path    => ['/bin/'],
   }
 

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -30,6 +30,7 @@ define typo3::install::source (
     command => "wget ${typo3::params::download_url}/${version} -O ${source_file}",
     cwd     => $src_path,
     onlyif  => "test ! -d typo3_src-${version}",
+    path    => ['/bin/'],
   }
 
   exec { "Untar ${name}":
@@ -37,6 +38,7 @@ define typo3::install::source (
     cwd     => $src_path,
     require => Exec["Get ${name}"],
     creates => "${src_path}/typo3_src-${version}",
+    path    => ['/bin/'],
   }
 
   exec { "Remove ${name}":
@@ -44,6 +46,7 @@ define typo3::install::source (
     cwd     => $src_path,
     require => Exec["Untar ${name}"],
     onlyif  => "test ! -f ${src_path}/${source_file}",
+    path    => ['/bin/'],
   }
 
 }

--- a/manifests/install/source/files.pp
+++ b/manifests/install/source/files.pp
@@ -51,6 +51,7 @@ define typo3::install::source::files (
       cwd     => $site_path,
       require => File["${target}"],
       unless  => 'test -L index.php',
+      path    => ['/bin/'],
     }
 
     exec { "${site_path}: ln -s typo3_src/typo3 typo3":
@@ -58,19 +59,21 @@ define typo3::install::source::files (
       cwd     => $site_path,
       require => File["${target}"],
       unless  => 'test -d typo3',
+      path    => ['/bin/'],
     }
 
-    unless $version > "6.1.99" {
+    if versioncmp($version, "6.1.99") < 0 {
       exec { "${site_path}: ln -s typo3_src/t3lib t3lib":
         command => 'ln -s typo3_src/t3lib t3lib',
         cwd     => $site_path,
         require => File["${target}"],
         unless  => 'test -d t3lib',
+        path    => ['/bin/'],
       }
     }
 
   } else {
-  
+
     file { "${site_path}/index.php":
       source => "${source}/index.php",
       ensure => 'present'
@@ -82,7 +85,7 @@ define typo3::install::source::files (
       ensure  => 'present'
     }
 
-    unless $version =~ /^6\.2/ {
+    if versioncmp($version, "6.1.99") < 0 {
       file { "${site_path}/t3lib":
         source  => "${source}/t3lib",
         recurse => true,


### PR DESCRIPTION
Hi,
i use puppet 3.7 and i must set the exec Path for the exec resources. I don't know how it works on our system.

Version Checks should be done with versioncmp. the function versioncmp can be used also in puppet 2.7
https://docs.puppetlabs.com/references/2.7.stable/function.html#versioncmp

greetings
Reamer
